### PR TITLE
feat: Add EXT-X-BITRATE to hls-parser

### DIFF
--- a/packages/web-media-box/src/hls-parser/consts/tags.ts
+++ b/packages/web-media-box/src/hls-parser/consts/tags.ts
@@ -17,3 +17,4 @@ export const EXT_X_DISCONTINUITY = 'EXT_X_DISCONTINUITY';
 export const EXT_X_KEY = 'EXT_X_KEY';
 export const EXT_X_MAP = 'EXT_X_MAP';
 export const EXT_X_GAP = 'EXT-X-GAP';
+export const EXT_X_BITRATE = 'EXT-X-BITRATE';

--- a/packages/web-media-box/src/hls-parser/tags/tagWithValueProcessors.ts
+++ b/packages/web-media-box/src/hls-parser/tags/tagWithValueProcessors.ts
@@ -7,7 +7,8 @@ import {
   EXT_X_TARGETDURATION,
   EXT_X_VERSION,
   EXTINF,
-  EXT_X_BYTERANGE
+  EXT_X_BYTERANGE,
+  EXT_X_BITRATE
 } from '../consts/tags.ts';
 import { fallbackUsedWarn, unableToParseValueWarn, unsupportedEnumValue } from '../utils/warn.ts';
 
@@ -138,5 +139,22 @@ export class ExtXByteRange extends TagWithValueProcessor {
         to: start + length - 1
       };
     }
+  }
+}
+
+export class ExtXBitrate extends TagWithValueProcessor {
+  protected readonly tag = EXT_X_BITRATE;
+
+  public process(tagValue: string, playlist: ParsedPlaylist, currentSegment: Segment): void {
+    const bitrate = Number(tagValue);
+
+    if (Number.isNaN(bitrate) || bitrate < 0) {
+      return this.warnCallback(unableToParseValueWarn(this.tag));
+    }
+
+    currentSegment.bitrate = bitrate;
+
+    // Store on the playlist so the bitrate value can be applied to subsequent segments
+    playlist.currentBitrate = bitrate;
   }
 }

--- a/packages/web-media-box/src/hls-parser/types/parsedPlaylist.d.ts
+++ b/packages/web-media-box/src/hls-parser/types/parsedPlaylist.d.ts
@@ -37,6 +37,7 @@ export interface Segment {
   duration: number;
   title?: string;
   byteRange?: ByteRange;
+  bitrate?: number;
   uri: string;
   isDiscontinuity: boolean;
   isGap: boolean
@@ -75,4 +76,6 @@ export interface ParsedPlaylist {
   mediaInitializationSection?: MediaInitializationSection;
   segments: Array<Segment>;
   custom: Record<string, unknown>;
+  // Used to persist EXT_X_BITRATE across segments
+  currentBitrate?: number
 }


### PR DESCRIPTION
## Description
The `EXT-X-BITRATE` tag “applies to every Media Segment between it and the next EXT-X-BITRATE tag in the Playlist file (or the end of the Playlist file) that does not have an EXT-X-BYTERANGE tag applied to it.” ([spec](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.4.8))

To support this I added a `currentBitrate` property to the `ParsedPlaylist` interface because it was a simple way to persist the bitrate value across segments with the current architecture. However, it doesn’t seem ideal because it doesn’t represent an actual property of the playlist itself, and is functioning simply as a flag. Since we are trying to move quickly I didn't give other possibilities much thought, but wanted to call it out here.