### PR TITLE
feat: parse EXT-X-PRELOAD-HINT tags and attributes

### DIFF
--- a/packages/web-media-box/src/hls-parser/consts/tags.ts
+++ b/packages/web-media-box/src/hls-parser/consts/tags.ts
@@ -25,3 +25,4 @@ export const EXT_X_MEDIA = 'EXT-X-MEDIA';
 export const EXT_X_STREAM_INF = 'EXT-X-STREAM-INF';
 export const EXT_X_I_FRAME_STREAM_INF = 'EXT-X-I-FRAME-STREAM-INF';
 export const EXT_X_DATERANGE = 'EXT-X-DATERANGE';
+export const EXT_X_PRELOAD_HINT = 'EXT-X-PRELOAD-HINT';

--- a/packages/web-media-box/src/hls-parser/parse.ts
+++ b/packages/web-media-box/src/hls-parser/parse.ts
@@ -30,6 +30,7 @@ import {
   EXT_X_SKIP,
   EXT_X_I_FRAME_STREAM_INF,
   EXT_X_DATERANGE,
+  EXT_X_PRELOAD_HINT,
 } from './consts/tags.ts';
 import type {
   CustomTagMap,
@@ -74,6 +75,7 @@ import {
   ExtXSkip,
   ExtXIFrameStreamInf,
   ExtXDaterange,
+  ExtXPreloadHint,
 } from './tags/tagWithAttributesProcessors.ts';
 
 const defaultSegment: Segment = {
@@ -127,6 +129,7 @@ class Parser {
       variantStreams: [],
       iFramePlaylists: [],
       dateRanges: [],
+      preloadHints: [],
     };
 
     this.sharedState = {
@@ -167,6 +170,7 @@ class Parser {
       [EXT_X_SKIP]: new ExtXSkip(this.warnCallback),
       [EXT_X_I_FRAME_STREAM_INF]: new ExtXIFrameStreamInf(this.warnCallback),
       [EXT_X_DATERANGE]: new ExtXDaterange(this.warnCallback),
+      [EXT_X_PRELOAD_HINT]: new ExtXPreloadHint(this.warnCallback),
     };
   }
 

--- a/packages/web-media-box/src/hls-parser/tags/tagWithAttributesProcessors.ts
+++ b/packages/web-media-box/src/hls-parser/tags/tagWithAttributesProcessors.ts
@@ -1,4 +1,4 @@
-import type { ParsedPlaylist, PartialSegment, Rendition, RenditionType, RenditionGroups, GroupId, Resolution, AllowedCpc, IFramePlaylist, BaseStreamInf, DateRange, Cue } from '../types/parsedPlaylist';
+import type { ParsedPlaylist, PartialSegment, Rendition, RenditionType, RenditionGroups, GroupId, Resolution, AllowedCpc, IFramePlaylist, BaseStreamInf, DateRange, Cue, HintType } from '../types/parsedPlaylist';
 import type { SharedState } from '../types/sharedState';
 import { TagProcessor } from './base.ts';
 import { missingRequiredAttributeWarn } from '../utils/warn.ts';
@@ -14,6 +14,7 @@ import {
   EXT_X_STREAM_INF,
   EXT_X_I_FRAME_STREAM_INF,
   EXT_X_DATERANGE,
+  EXT_X_PRELOAD_HINT,
 } from '../consts/tags.ts';
 import { parseBoolean } from '../utils/parse.ts';
 
@@ -415,4 +416,26 @@ export class ExtXDaterange extends TagWithAttributesProcessor {
 
     playlist.dateRanges.push(dateRange);
   }
+}
+
+export class ExtXPreloadHint extends TagWithAttributesProcessor {
+  private static readonly TYPE = 'TYPE';
+  private static readonly URI = 'URI';
+  private static readonly BYTERANGE_START = 'BYTERANGE-START';
+  private static readonly BYTERANGE_LENGTH = 'BYTERANGE-LENGTH';
+  
+  protected requiredAttributes = new Set([ExtXPreloadHint.TYPE, ExtXPreloadHint.URI]);
+  protected tag = EXT_X_PRELOAD_HINT;
+
+  protected safeProcess(tagAttributes: Record<string, string>, playlist: ParsedPlaylist): void {
+    const preloadHint = {
+      type: tagAttributes[ExtXPreloadHint.TYPE] as HintType,
+      uri: tagAttributes[ExtXPreloadHint.URI],
+      byterangeStart: Number(tagAttributes[ExtXPreloadHint.BYTERANGE_START]),
+      byterangeLength: Number(tagAttributes[ExtXPreloadHint.BYTERANGE_LENGTH])
+    };
+
+    playlist.preloadHints.push(preloadHint);
+  }
+
 }

--- a/packages/web-media-box/src/hls-parser/tags/tagWithAttributesProcessors.ts
+++ b/packages/web-media-box/src/hls-parser/tags/tagWithAttributesProcessors.ts
@@ -437,5 +437,4 @@ export class ExtXPreloadHint extends TagWithAttributesProcessor {
 
     playlist.preloadHints.push(preloadHint);
   }
-
 }

--- a/packages/web-media-box/src/hls-parser/types/parsedPlaylist.d.ts
+++ b/packages/web-media-box/src/hls-parser/types/parsedPlaylist.d.ts
@@ -142,6 +142,18 @@ export interface Skip {
   recentlyRemovedDateranges?: Array<string>;
 }
 
+export enum HintType {
+  PART = 'PART',
+  MAP = 'MAP'
+}
+
+export interface PreloadHint {
+  type: HintType;
+  uri: string;
+  byterangeStart?: number;
+  byterangeLength?: number;
+}
+
 export type PlaylistType = 'EVENT' | 'VOD';
 
 export interface ParsedPlaylist {
@@ -182,4 +194,6 @@ export interface ParsedPlaylist {
   iFramePlaylists: Array<IFramePlaylist>
   // https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.5.2
   skip?: Skip;
+  // https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.5.3
+  preloadHints: PreloadHint[];
 }


### PR DESCRIPTION
Support `EXT-X-PRELOAD-HINT` tags and attributes.
https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.5.3